### PR TITLE
Add AL2023 CloudFormation template for trn2 EKS node groups

### DIFF
--- a/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
+++ b/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
@@ -10,6 +10,9 @@ Metadata:
         Parameters:
           - ClusterName
           - ClusterControlPlaneSecurityGroup
+          - ClusterCertificateAuthority
+          - ClusterEndpoint
+          - ClusterServiceCidr
       - Label:
           default: Worker Node Configuration
         Parameters:
@@ -30,6 +33,19 @@ Parameters:
     Type: String
     Description: The cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster.
 
+  ClusterEndpoint:
+    Type: String
+    Description: The API server endpoint for the EKS cluster. Obtain via aws eks describe-cluster --name <name> --query 'cluster.endpoint' --output text
+
+  ClusterCertificateAuthority:
+    Type: String
+    Description: The base64-encoded certificate authority data for the EKS cluster. Obtain via aws eks describe-cluster --name <name> --query 'cluster.certificateAuthority.data' --output text
+
+  ClusterServiceCidr:
+    Type: String
+    Default: "10.100.0.0/16"
+    Description: The Kubernetes service CIDR for the EKS cluster. Obtain via aws eks describe-cluster --name <name> --query 'cluster.kubernetesNetworkConfig.serviceIpv4Cidr' --output text
+
   NodeImageId:
     Type: String
     Default: ""
@@ -37,7 +53,7 @@ Parameters:
 
   NodeImageIdSSMParam:
     Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
-    Default: /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/standard/recommended/image_id
+    Default: /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/neuron/recommended/image_id
     Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
 
   NodeVolumeSize:
@@ -347,8 +363,6 @@ Resources:
             InterfaceType: efa
         Placement:
           GroupName: !Ref PlacementGroupTrn2
-        IamInstanceProfile:
-          Arn: !GetAtt NodeInstanceProfile.Arn
         UserData: !Base64
           "Fn::Sub": |
             Content-Type: multipart/mixed; boundary="==BOUNDARY=="
@@ -356,51 +370,33 @@ Resources:
 
             --==BOUNDARY==
             Content-Type: text/cloud-boothook; charset="us-ascii"
+
+            #!/bin/bash
             cloud-init-per once yum_wget yum install -y wget
             cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
-
             cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
-            pushd /tmp/aws-efa-installer
+            
+            cd /tmp/aws-efa-installer
             cloud-init-per once install_efa ./efa_installer.sh -y -g
-            pop /tmp/aws-efa-installer
-
             cloud-init-per once efa_info /opt/amazon/efa/bin/fi_info -p efa
 
             --==BOUNDARY==
-            Content-Type: text/x-shellscript; charset="us-ascii"
+            Content-Type: application/node.eks.aws
 
-            #!/bin/bash
-            set -o xtrace
-            aws eks describe-cluster \
-              --region=${AWS::Region} \
-              --name=${ClusterName} \
-              --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, serviceIpv4Cidr: kubernetesNetworkConfig.serviceIpv4Cidr, serviceIpv6Cidr: kubernetesNetworkConfig.serviceIpv6Cidr}' > /tmp/describe_cluster_result.json
-
-            CA=$(cat /tmp/describe_cluster_result.json | grep certificateAuthorityData | awk '{print $2}' | sed 's/[,"]//g')
-            APISERVER_ENDPOINT=$(cat /tmp/describe_cluster_result.json | grep endpoint | awk '{print $2}' | sed 's/[,"]//g')
-            SERVICE_IPV6_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv6Cidr | awk '{print $2}' | sed 's/[,"]//g')
-            if [[ ! -z "$SERVICE_IPV6_CIDR" && "$SERVICE_IPV6_CIDR" != "null" ]]; then
-              SERVICE_CIDR=$SERVICE_IPV6_CIDR
-            else
-              SERVICE_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv4Cidr | awk '{print $2}' | sed 's/[,"]//g')
-            fi
-
-            cat > /tmp/nodeadm-config.yaml << EOF
             apiVersion: node.eks.aws/v1alpha1
             kind: NodeConfig
             spec:
               cluster:
                 name: ${ClusterName}
-                apiServerEndpoint: $APISERVER_ENDPOINT
-                certificateAuthority: $CA
-                cidr: $SERVICE_CIDR
-            EOF
-            nodeadm init --config-source file:///tmp/nodeadm-config.yaml
+                apiServerEndpoint: ${ClusterEndpoint}
+                certificateAuthority: ${ClusterCertificateAuthority}
+                cidr: ${ClusterServiceCidr}
 
             --==BOUNDARY==--
 
         MetadataOptions:
           "HttpPutResponseHopLimit": 2
+  NodeLaunchTemplateTrn2u:
     Type: "AWS::EC2::LaunchTemplate"
     Properties:
       LaunchTemplateData:
@@ -535,8 +531,6 @@ Resources:
             InterfaceType: efa
         Placement:
           GroupName: !Ref PlacementGroupTrn2u
-        IamInstanceProfile:
-          Arn: !GetAtt NodeInstanceProfile.Arn
         UserData: !Base64
           "Fn::Sub": |
             Content-Type: multipart/mixed; boundary="==BOUNDARY=="
@@ -544,51 +538,34 @@ Resources:
 
             --==BOUNDARY==
             Content-Type: text/cloud-boothook; charset="us-ascii"
-            cloud-init-per once yum_wget yum install -y wget
-            cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
-
-            cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
-            pushd /tmp/aws-efa-installer
-            cloud-init-per once install_efa ./efa_installer.sh -y -g
-            pop /tmp/aws-efa-installer
-
-            cloud-init-per once efa_info /opt/amazon/efa/bin/fi_info -p efa
-
-            --==BOUNDARY==
-            Content-Type: text/x-shellscript; charset="us-ascii"
 
             #!/bin/bash
-            set -o xtrace
-            aws eks describe-cluster \
-              --region=${AWS::Region} \
-              --name=${ClusterName} \
-              --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, serviceIpv4Cidr: kubernetesNetworkConfig.serviceIpv4Cidr, serviceIpv6Cidr: kubernetesNetworkConfig.serviceIpv6Cidr}' > /tmp/describe_cluster_result.json
+            cloud-init-per once yum_wget yum install -y wget
+            cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
+            cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
+            
+            cd /tmp/aws-efa-installer
+            cloud-init-per once install_efa ./efa_installer.sh -y -g
+            cloud-init-per once efa_info /opt/amazon/efa/bin/fi_info -p efa
 
-            CA=$(cat /tmp/describe_cluster_result.json | grep certificateAuthorityData | awk '{print $2}' | sed 's/[,"]//g')
-            APISERVER_ENDPOINT=$(cat /tmp/describe_cluster_result.json | grep endpoint | awk '{print $2}' | sed 's/[,"]//g')
-            SERVICE_IPV6_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv6Cidr | awk '{print $2}' | sed 's/[,"]//g')
-            if [[ ! -z "$SERVICE_IPV6_CIDR" && "$SERVICE_IPV6_CIDR" != "null" ]]; then
-              SERVICE_CIDR=$SERVICE_IPV6_CIDR
-            else
-              SERVICE_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv4Cidr | awk '{print $2}' | sed 's/[,"]//g')
-            fi
 
-            cat > /tmp/nodeadm-config.yaml << EOF
+            --==BOUNDARY==
+            Content-Type: application/node.eks.aws
+
             apiVersion: node.eks.aws/v1alpha1
             kind: NodeConfig
             spec:
               cluster:
                 name: ${ClusterName}
-                apiServerEndpoint: $APISERVER_ENDPOINT
-                certificateAuthority: $CA
-                cidr: $SERVICE_CIDR
-            EOF
-            nodeadm init --config-source file:///tmp/nodeadm-config.yaml
+                apiServerEndpoint: ${ClusterEndpoint}
+                certificateAuthority: ${ClusterCertificateAuthority}
+                cidr: ${ClusterServiceCidr}
 
             --==BOUNDARY==--
 
         MetadataOptions:
           "HttpPutResponseHopLimit": 2
+Outputs:
   EKSClusterName:
     Description: EKS Cluster
     Value: !Ref ClusterName

--- a/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
+++ b/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
@@ -361,6 +361,62 @@ Resources:
             Groups:
               - !Ref NodeSecurityGroup
             InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 8
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 9
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 10
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 11
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 12
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 13
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 14
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 15
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
         Placement:
           GroupName: !Ref PlacementGroupTrn2
         UserData: !Base64

--- a/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
+++ b/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
@@ -351,23 +351,56 @@ Resources:
           Arn: !GetAtt NodeInstanceProfile.Arn
         UserData: !Base64
           "Fn::Sub": |
-            ---
+            Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+            MIME-Version: 1.0
+
+            --==BOUNDARY==
+            Content-Type: text/cloud-boothook; charset="us-ascii"
+            cloud-init-per once yum_wget yum install -y wget
+            cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
+
+            cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
+            pushd /tmp/aws-efa-installer
+            cloud-init-per once install_efa ./efa_installer.sh -y -g
+            pop /tmp/aws-efa-installer
+
+            cloud-init-per once efa_info /opt/amazon/efa/bin/fi_info -p efa
+
+            --==BOUNDARY==
+            Content-Type: text/x-shellscript; charset="us-ascii"
+
+            #!/bin/bash
+            set -o xtrace
+            aws eks describe-cluster \
+              --region=${AWS::Region} \
+              --name=${ClusterName} \
+              --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, serviceIpv4Cidr: kubernetesNetworkConfig.serviceIpv4Cidr, serviceIpv6Cidr: kubernetesNetworkConfig.serviceIpv6Cidr}' > /tmp/describe_cluster_result.json
+
+            CA=$(cat /tmp/describe_cluster_result.json | grep certificateAuthorityData | awk '{print $2}' | sed 's/[,"]//g')
+            APISERVER_ENDPOINT=$(cat /tmp/describe_cluster_result.json | grep endpoint | awk '{print $2}' | sed 's/[,"]//g')
+            SERVICE_IPV6_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv6Cidr | awk '{print $2}' | sed 's/[,"]//g')
+            if [[ ! -z "$SERVICE_IPV6_CIDR" && "$SERVICE_IPV6_CIDR" != "null" ]]; then
+              SERVICE_CIDR=$SERVICE_IPV6_CIDR
+            else
+              SERVICE_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv4Cidr | awk '{print $2}' | sed 's/[,"]//g')
+            fi
+
+            cat > /tmp/nodeadm-config.yaml << EOF
             apiVersion: node.eks.aws/v1alpha1
             kind: NodeConfig
             spec:
               cluster:
                 name: ${ClusterName}
-                apiServerEndpoint: https://${ClusterName}.eks.${AWS::Region}.amazonaws.com
-                certificateAuthority: ""
-              kubelet:
-                config:
-                  clusterDNS:
-                    - 10.100.0.10
+                apiServerEndpoint: $APISERVER_ENDPOINT
+                certificateAuthority: $CA
+                cidr: $SERVICE_CIDR
+            EOF
+            nodeadm init --config-source file:///tmp/nodeadm-config.yaml
+
+            --==BOUNDARY==--
 
         MetadataOptions:
           "HttpPutResponseHopLimit": 2
-
-  NodeLaunchTemplateTrn2u:
     Type: "AWS::EC2::LaunchTemplate"
     Properties:
       LaunchTemplateData:
@@ -506,23 +539,56 @@ Resources:
           Arn: !GetAtt NodeInstanceProfile.Arn
         UserData: !Base64
           "Fn::Sub": |
-            ---
+            Content-Type: multipart/mixed; boundary="==BOUNDARY=="
+            MIME-Version: 1.0
+
+            --==BOUNDARY==
+            Content-Type: text/cloud-boothook; charset="us-ascii"
+            cloud-init-per once yum_wget yum install -y wget
+            cloud-init-per once wget_efa wget -q --timeout=20 https://s3-us-west-2.amazonaws.com/aws-efa-installer/aws-efa-installer-latest.tar.gz -O /tmp/aws-efa-installer-latest.tar.gz
+
+            cloud-init-per once tar_efa tar -xf /tmp/aws-efa-installer-latest.tar.gz -C /tmp
+            pushd /tmp/aws-efa-installer
+            cloud-init-per once install_efa ./efa_installer.sh -y -g
+            pop /tmp/aws-efa-installer
+
+            cloud-init-per once efa_info /opt/amazon/efa/bin/fi_info -p efa
+
+            --==BOUNDARY==
+            Content-Type: text/x-shellscript; charset="us-ascii"
+
+            #!/bin/bash
+            set -o xtrace
+            aws eks describe-cluster \
+              --region=${AWS::Region} \
+              --name=${ClusterName} \
+              --query 'cluster.{certificateAuthorityData: certificateAuthority.data, endpoint: endpoint, serviceIpv4Cidr: kubernetesNetworkConfig.serviceIpv4Cidr, serviceIpv6Cidr: kubernetesNetworkConfig.serviceIpv6Cidr}' > /tmp/describe_cluster_result.json
+
+            CA=$(cat /tmp/describe_cluster_result.json | grep certificateAuthorityData | awk '{print $2}' | sed 's/[,"]//g')
+            APISERVER_ENDPOINT=$(cat /tmp/describe_cluster_result.json | grep endpoint | awk '{print $2}' | sed 's/[,"]//g')
+            SERVICE_IPV6_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv6Cidr | awk '{print $2}' | sed 's/[,"]//g')
+            if [[ ! -z "$SERVICE_IPV6_CIDR" && "$SERVICE_IPV6_CIDR" != "null" ]]; then
+              SERVICE_CIDR=$SERVICE_IPV6_CIDR
+            else
+              SERVICE_CIDR=$(cat /tmp/describe_cluster_result.json | grep serviceIpv4Cidr | awk '{print $2}' | sed 's/[,"]//g')
+            fi
+
+            cat > /tmp/nodeadm-config.yaml << EOF
             apiVersion: node.eks.aws/v1alpha1
             kind: NodeConfig
             spec:
               cluster:
                 name: ${ClusterName}
-                apiServerEndpoint: https://${ClusterName}.eks.${AWS::Region}.amazonaws.com
-                certificateAuthority: ""
-              kubelet:
-                config:
-                  clusterDNS:
-                    - 10.100.0.10
+                apiServerEndpoint: $APISERVER_ENDPOINT
+                certificateAuthority: $CA
+                cidr: $SERVICE_CIDR
+            EOF
+            nodeadm init --config-source file:///tmp/nodeadm-config.yaml
+
+            --==BOUNDARY==--
 
         MetadataOptions:
           "HttpPutResponseHopLimit": 2
-
-Outputs:
   EKSClusterName:
     Description: EKS Cluster
     Value: !Ref ClusterName

--- a/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
+++ b/dp_bert_hf_pretrain/cfn/eks_trn2_ng_stack_al2023.yaml
@@ -1,0 +1,548 @@
+AWSTemplateFormatVersion: "2010-09-09"
+
+Description: Amazon EKS - Nodegroup resources for trn2.48xlarge and trn2u.48xlarge instances
+
+Metadata:
+  "AWS::CloudFormation::Interface":
+    ParameterGroups:
+      - Label:
+          default: EKS Cluster
+        Parameters:
+          - ClusterName
+          - ClusterControlPlaneSecurityGroup
+      - Label:
+          default: Worker Node Configuration
+        Parameters:
+          - NodeImageIdSSMParam
+          - NodeImageId
+          - NodeVolumeSize
+      - Label:
+          default: Worker Network Configuration
+        Parameters:
+          - VpcId
+
+Parameters:
+  ClusterControlPlaneSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup::Id"
+    Description: The security group of the cluster control plane.
+
+  ClusterName:
+    Type: String
+    Description: The cluster name provided when the cluster was created. If it is incorrect, nodes will not be able to join the cluster.
+
+  NodeImageId:
+    Type: String
+    Default: ""
+    Description: (Optional) Specify your own custom image ID. This value overrides any AWS Systems Manager Parameter Store value specified above.
+
+  NodeImageIdSSMParam:
+    Type: "AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>"
+    Default: /aws/service/eks/optimized-ami/1.34/amazon-linux-2023/x86_64/standard/recommended/image_id
+    Description: AWS Systems Manager Parameter Store parameter of the AMI ID for the worker node instances.
+
+  NodeVolumeSize:
+    Type: Number
+    Default: 500
+    Description: Node volume size
+
+  VpcId:
+    Type: "AWS::EC2::VPC::Id"
+    Description: The VPC of the worker instances
+
+Mappings:
+  PartitionMap:
+    aws:
+      EC2ServicePrincipal: "ec2.amazonaws.com"
+    aws-us-gov:
+      EC2ServicePrincipal: "ec2.amazonaws.com"
+    aws-cn:
+      EC2ServicePrincipal: "ec2.amazonaws.com.cn"
+    aws-iso:
+      EC2ServicePrincipal: "ec2.c2s.ic.gov"
+    aws-iso-b:
+      EC2ServicePrincipal: "ec2.sc2s.sgov.gov"
+
+Conditions:
+  HasNodeImageId: !Not
+    - "Fn::Equals":
+        - Ref: NodeImageId
+        - ""
+
+Resources:
+
+  PlacementGroupTrn2:
+   Type: AWS::EC2::PlacementGroup
+   Properties:
+     Strategy: cluster
+
+  PlacementGroupTrn2u:
+   Type: AWS::EC2::PlacementGroup
+   Properties:
+     Strategy: cluster
+  
+  NodeInstanceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - !FindInMap [PartitionMap, !Ref "AWS::Partition", EC2ServicePrincipal]
+            Action:
+              - "sts:AssumeRole"
+      ManagedPolicyArns:
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEKS_CNI_Policy"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+        - !Sub 'arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore'
+      Path: /
+
+  NodeInstanceProfile:
+    Type: "AWS::IAM::InstanceProfile"
+    Properties:
+      Path: /
+      Roles:
+        - Ref: NodeInstanceRole
+
+  NodeSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties:
+      GroupDescription: Security group for all nodes in the cluster
+      Tags:
+        - Key: !Sub kubernetes.io/cluster/${ClusterName}
+          Value: owned
+      VpcId: !Ref VpcId
+
+  NodeSecurityGroupIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow node to communicate with each other
+      FromPort: 0
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "-1"
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort: 65535
+
+  NodeSecurityGroupEgress:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the efa worker nodes outbound communication
+      DestinationSecurityGroupId: !Ref NodeSecurityGroup
+      FromPort: 0
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "-1"
+      ToPort: 65536
+  
+  NodeSecurityGroupEgressAllIpv4:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the efa worker nodes outbound communication
+      FromPort: 0
+      CidrIp: "0.0.0.0/0"
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "-1"
+      ToPort: 65536
+
+  NodeSecurityGroupEgressAllIpv6:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the efa worker nodes outbound communication
+      FromPort: 0
+      CidrIpv6: "::/0"
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "-1"
+      ToPort: 65536
+  
+  NodeSecurityGroupIngressSSHIpv4:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow SSH
+      FromPort: 22
+      CidrIp: "0.0.0.0/0"
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "tcp"
+      ToPort: 22
+
+  NodeSecurityGroupIngressSSHIpv6:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow SSH
+      FromPort: 22
+      CidrIpv6: "::/0"
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: "tcp"
+      ToPort: 22
+
+  ClusterControlPlaneSecurityGroupIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow pods to communicate with the cluster API Server
+      FromPort: 443
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort: 443
+
+  ControlPlaneEgressToNodeSecurityGroup:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the cluster control plane to communicate with worker Kubelet and pods
+      DestinationSecurityGroupId: !Ref NodeSecurityGroup
+      FromPort: 1025
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      ToPort: 65535
+
+  ControlPlaneEgressToNodeSecurityGroupOn443:
+    Type: "AWS::EC2::SecurityGroupEgress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow the cluster control plane to communicate with pods running extension API servers on port 443
+      DestinationSecurityGroupId: !Ref NodeSecurityGroup
+      FromPort: 443
+      GroupId: !Ref ClusterControlPlaneSecurityGroup
+      IpProtocol: tcp
+      ToPort: 443
+
+  NodeSecurityGroupFromControlPlaneIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow worker Kubelets and pods to receive communication from the cluster control plane
+      FromPort: 1025
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+      ToPort: 65535
+
+  NodeSecurityGroupFromControlPlaneOn443Ingress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      Description: Allow pods running extension API servers on port 443 to receive communication from cluster control plane
+      FromPort: 443
+      GroupId: !Ref NodeSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref ClusterControlPlaneSecurityGroup
+      ToPort: 443
+
+  LustreSecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    DependsOn: NodeSecurityGroup
+    Properties:
+      GroupDescription: Security group used by FSx for Lustre
+      Tags:
+        - Key: !Sub kubernetes.io/cluster/${ClusterName}
+          Value: owned
+      VpcId: !Ref VpcId
+
+  LustreSecurityGroupSelfIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: LustreSecurityGroup
+    Properties:
+      Description: Allow traffic between Lustre nodes
+      FromPort: 988
+      GroupId: !Ref LustreSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref LustreSecurityGroup
+      ToPort: 988
+
+  LustreSecurityGroupEksNodeIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    DependsOn: LustreSecurityGroup
+    Properties:
+      Description: Allow traffic between FSx for Lustre and Lustre clients
+      FromPort: 988
+      GroupId: !Ref LustreSecurityGroup
+      IpProtocol: tcp
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort: 988
+
+  NodeLaunchTemplateTrn2:
+    Type: "AWS::EC2::LaunchTemplate"
+    Properties:
+      LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              DeleteOnTermination: true
+              VolumeSize: !Ref NodeVolumeSize
+              VolumeType: gp3
+        ImageId: !If
+          - HasNodeImageId
+          - Ref: NodeImageId
+          - Ref: NodeImageIdSSMParam
+        InstanceType: trn2.48xlarge
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Name
+                Value: !Sub ${ClusterName}-trn2-48xl-ng1
+        NetworkInterfaces:
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 0
+            DeviceIndex: 0
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 1
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 2
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 3
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 4
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 5
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 6
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 7
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+        Placement:
+          GroupName: !Ref PlacementGroupTrn2
+        IamInstanceProfile:
+          Arn: !GetAtt NodeInstanceProfile.Arn
+        UserData: !Base64
+          "Fn::Sub": |
+            ---
+            apiVersion: node.eks.aws/v1alpha1
+            kind: NodeConfig
+            spec:
+              cluster:
+                name: ${ClusterName}
+                apiServerEndpoint: https://${ClusterName}.eks.${AWS::Region}.amazonaws.com
+                certificateAuthority: ""
+              kubelet:
+                config:
+                  clusterDNS:
+                    - 10.100.0.10
+
+        MetadataOptions:
+          "HttpPutResponseHopLimit": 2
+
+  NodeLaunchTemplateTrn2u:
+    Type: "AWS::EC2::LaunchTemplate"
+    Properties:
+      LaunchTemplateData:
+        BlockDeviceMappings:
+          - DeviceName: /dev/xvda
+            Ebs:
+              DeleteOnTermination: true
+              VolumeSize: !Ref NodeVolumeSize
+              VolumeType: gp3
+        ImageId: !If
+          - HasNodeImageId
+          - Ref: NodeImageId
+          - Ref: NodeImageIdSSMParam
+        InstanceType: trn2u.48xlarge
+        TagSpecifications:
+          - ResourceType: instance
+            Tags:
+              - Key: Name
+                Value: !Sub ${ClusterName}-trn2u-48xl-ng1
+        NetworkInterfaces:
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 0
+            DeviceIndex: 0
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 1
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 2
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 3
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 4
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 5
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 6
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 7
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 8
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 9
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 10
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 11
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 12
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 13
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 14
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+          - Description: NetworkInterfaces Configuration For EFA and EKS
+            NetworkCardIndex: 15
+            DeviceIndex: 1
+            DeleteOnTermination: true
+            Groups:
+              - !Ref NodeSecurityGroup
+            InterfaceType: efa
+        Placement:
+          GroupName: !Ref PlacementGroupTrn2u
+        IamInstanceProfile:
+          Arn: !GetAtt NodeInstanceProfile.Arn
+        UserData: !Base64
+          "Fn::Sub": |
+            ---
+            apiVersion: node.eks.aws/v1alpha1
+            kind: NodeConfig
+            spec:
+              cluster:
+                name: ${ClusterName}
+                apiServerEndpoint: https://${ClusterName}.eks.${AWS::Region}.amazonaws.com
+                certificateAuthority: ""
+              kubelet:
+                config:
+                  clusterDNS:
+                    - 10.100.0.10
+
+        MetadataOptions:
+          "HttpPutResponseHopLimit": 2
+
+Outputs:
+  EKSClusterName:
+    Description: EKS Cluster
+    Value: !Ref ClusterName
+
+  NodeInstanceRole:
+    Description: The node instance role
+    Value: !GetAtt NodeInstanceRole.Arn
+
+  LaunchTemplateIdTrn2:
+    Description: The launch template created for Trn2.48xlarge instances
+    Value: !Ref NodeLaunchTemplateTrn2
+
+  LaunchTemplateIdTrn2u:
+    Description: The launch template created for Trn2u.48xlarge instances
+    Value: !Ref NodeLaunchTemplateTrn2u
+
+  NodeSecurityGroup:
+    Description: SG used by all nodes in this NodeGroup
+    Value: !Ref NodeSecurityGroup
+
+  LustreSecurityGroup:
+    Description: SG used by FSx for Lustre
+    Value: !Ref LustreSecurityGroup


### PR DESCRIPTION
*Description of changes:*

Add AL2023 CloudFormation template for Trn2 EKS node groups

- Support for trn2.48xlarge and trn2u.48xlarge instance types, both containing 16 EFA devices
- Uses AL2023 EKS optimized AMI with nodeadm bootstrap
